### PR TITLE
fix(security): remediate python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret at good/libapi.py

### DIFF
--- a/good/libapi.py
+++ b/good/libapi.py
@@ -1,4 +1,5 @@
 import libuser
+import os
 import random
 import hashlib
 import re
@@ -7,7 +8,7 @@ from time import time
 
 from pathlib import Path
 
-secret = 'MYSUPERSECRETKEY'
+secret = os.environ.get('VULPY_JWT_SECRET') or os.urandom(32).hex()
 not_after = 60 # 1 minute
 
 def keygen(username, password=None, login=True):
@@ -48,4 +49,3 @@ def authenticate(request):
         return None
 
     return decoded['username']
-


### PR DESCRIPTION
Remediates the SARIF finding in good/libapi.py by loading the JWT signing secret from VULPY_JWT_SECRET, with a random fallback instead of a hardcoded value.