### PR TITLE
fix(security): remediate python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_SECRET_KEY at good/vulpy.py

### DIFF
--- a/good/vulpy.py
+++ b/good/vulpy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 from pathlib import Path
 
 from flask import Flask, g, redirect, request
@@ -14,7 +15,7 @@ from mod_api import mod_api
 import libsession
 
 app = Flask('vulpy')
-app.config['SECRET_KEY'] = '123aa8a93bdde342c871564a62282af857bda14b3359fde95d0c5e4b321610c1'
+app.config['SECRET_KEY'] = os.environ.get('VULPY_SECRET_KEY') or os.urandom(32).hex()
 
 app.register_blueprint(mod_hello, url_prefix='/hello')
 app.register_blueprint(mod_user, url_prefix='/user')
@@ -51,4 +52,3 @@ def add_csp_headers(response):
     return response
 
 app.run(debug=True, host='127.0.1.1', port=5001, extra_files='csp.txt')
-


### PR DESCRIPTION
Remediates the SARIF finding in good/vulpy.py by sourcing the Flask SECRET_KEY from VULPY_SECRET_KEY, with a per-process random fallback instead of a hardcoded secret.