### PR TITLE
fix(security): remediate python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly at good/vulpy.py

### DIFF
--- a/good/vulpy.py
+++ b/good/vulpy.py
@@ -50,5 +50,5 @@ def add_csp_headers(response):
         response.headers['Content-Security-Policy'] = csp
     return response
 
-app.run(debug=True, host='127.0.1.1', port=5001, extra_files='csp.txt')
-
+if __name__ == '__main__':
+    app.run(debug=True, host='127.0.1.1', port=5001, extra_files='csp.txt')


### PR DESCRIPTION
Remediates the SARIF finding in good/vulpy.py by moving app.run(...) behind a __main__ guard so imports do not start the Flask server.