### PR TITLE
fix(security): remediate python.flask.security.audit.hardcoded-config.avoid_hardcoded_config_SECRET_KEY at good/vulpy-ssl.py

### DIFF
--- a/good/vulpy-ssl.py
+++ b/good/vulpy-ssl.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 from flask import Flask, g, redirect, request
 
 from mod_hello import mod_hello
@@ -10,7 +11,7 @@ from mod_mfa import mod_mfa
 import libsession
 
 app = Flask('vulpy')
-app.config['SECRET_KEY'] = 'aaaaaaa'
+app.config['SECRET_KEY'] = os.environ.get('VULPY_SECRET_KEY') or os.urandom(32).hex()
 
 app.register_blueprint(mod_hello, url_prefix='/hello')
 app.register_blueprint(mod_user, url_prefix='/user')


### PR DESCRIPTION
Remediates the SARIF finding in good/vulpy-ssl.py by sourcing the Flask SECRET_KEY from VULPY_SECRET_KEY, with a per-process random fallback instead of a hardcoded secret.