### PR TITLE
fix(security): remediate python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly at good/vulpy-ssl.py

### DIFF
--- a/good/vulpy-ssl.py
+++ b/good/vulpy-ssl.py
@@ -26,4 +26,5 @@ def do_home():
 def before_request():
     g.session = libsession.load(request)
 
-app.run(debug=True, host='127.0.1.1', ssl_context=('/tmp/acme.cert', '/tmp/acme.key'))
+if __name__ == '__main__':
+    app.run(debug=True, host='127.0.1.1', ssl_context=('/tmp/acme.cert', '/tmp/acme.key'))


### PR DESCRIPTION
Remediates the SARIF finding in good/vulpy-ssl.py by moving app.run(...) behind a __main__ guard so imports do not start the Flask server.